### PR TITLE
create ENV to tell the make on the URL of the package-repo

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -149,7 +149,7 @@ def cmd_make_command(props):
     else:
         command.extend(['-j', '2'])
     command.extend(["TARGET=" + props.getProperty('buildername')])
-    command.extend([Interpolate("PKGREPO_DIR=%(kw:pkgrepo)s", pkgrepo=repo_url)])
+    command.extend([Interpolate("REPOPATH=%(kw:pkgrepo)s", pkgrepo=repo_url)])
     return command
 
 

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -149,6 +149,7 @@ def cmd_make_command(props):
     else:
         command.extend(['-j', '2'])
     command.extend(["TARGET=" + props.getProperty('buildername')])
+    command.extend([Interpolate("PKGREPO_DIR=%(kw:pkgrepo)s", pkgrepo=repo_url)])
     return command
 
 


### PR DESCRIPTION
- currently the firmware Makefile is setting up the opkg-sources, but there is no way to include the correct build#

- I hope this code privides the build# via shell-env PKGREPO_DIR to the make commandline 
- this way we can make the cmd_change_version_repo() inside of makefile

see https://github.com/freifunk-berlin/firmware/issues/342 for this also