### PR TITLE
master: fix VERSION_REPO override by passing it to make

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -125,21 +125,6 @@ def repo_url(props):
             props.getProperty("buildnumber")
             )
 
-# replace CONFIG_VERSION_REPO with path to unstable build packages
-cmd_change_version_repo = ShellCommand(
-    command=[
-        "sed",
-        "-i",
-        Interpolate(
-            "s|^CONFIG_VERSION_REPO.*|CONFIG_VERSION_REPO=\"%(kw:repo_url)s\"|",
-            repo_url=repo_url
-        ),
-        Interpolate("configs/%(prop:buildername)s.config")
-    ],
-    workdir="build/firmware",
-    haltOnFailure=True
-    )
-
 @renderer
 def cmd_make_command(props):
     command = ['nice', 'make']
@@ -149,6 +134,7 @@ def cmd_make_command(props):
     else:
         command.extend(['-j', '2'])
     command.extend(["TARGET=" + props.getProperty('buildername')])
+    command.extend(["VERSION_REPO=" + repo_url(props)])
     return command
 
 
@@ -214,7 +200,6 @@ cmd_create_release_dir = MasterShellCommand(
 
 factory = BuildFactory([
     cmd_checkoutSource,
-    cmd_change_version_repo,
     cmd_make,
     cmd_mastermkdir,
     cmd_uploadPackages,


### PR DESCRIPTION
The VERSION_REPO was set via `sed -i` on the builder config. This broke
when all common config symbols got moved into a seperate file 1e75bbac.
Using make variable can work even with older build and newer builds and
also does not contaminate the git tree (adds dirty flag to git describe).