### PR TITLE
append subtarget name to all platforms

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -21,11 +21,11 @@ from buildbot.changes import filter
 from buildbot.schedulers.timed import Periodic
 
 builder_names = [
-    "ar71xx",
+    "ar71xx_generic",
     "ar71xx_mikrotik",
-    "mpc85xx",
-    "ramips",
-    "x86"
+    "mpc85xx_generic",
+    "ramips_generic",
+    "x86_generic"
     ]
 
 c['schedulers'] = []


### PR DESCRIPTION
When subtarget support was introduce, it was only used for target ar71xx_mikrotik
and none of the old targets e.g. ar71xx was renamed including it's subtarget.
Every platform has a subtarget, even when it's generic.
Rename those platform into $TARGET_$SUBTARGET
LEDE requires to know the subtarget, because it has a different bin/ directory
layout. It uses /bin/$TARGET/$SUBTARGET/foobar.sysupgrade.squashfs.bin

ar71xx -> ar71xx_generic
mpc85xx -> mpc85xx_generic
ramips -> ramip_mt7620
x86 -> x86_generic

Signed-off-by: Alexander Couzens lynxis@fe80.eu
