### PR TITLE
master.cfg: make release-detection more strict

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -74,7 +74,7 @@ from buildbot.steps.slave import RemoveDirectory
 
 def is_release_step(step):
     branch = step.build.getProperty("branch")
-    return re.match("\d+\.\d+\.\d+", branch)
+    return re.match("\d+\.\d+\.\d+$", branch)
 
 cmd_checkoutSource = Git(
     repourl='git://github.com/freifunk-berlin/firmware.git',
@@ -110,7 +110,7 @@ def repo_url(props):
     base_url = "http://buildbot.berlin.freifunk.net/buildbot"
     branch = props.getProperty("branch")
     target = props.getProperty("buildername")
-    is_release_branch = re.match("\d+\.\d+\.\d+", branch)
+    is_release_branch = re.match("\d+\.\d+\.\d+$", branch)
     if is_release_branch:
         return "{}/stable/{}/{}/packages".format(
             base_url,


### PR DESCRIPTION
add an anchor to the regex used when checking if we are building a release

fixes #36 