### PR TITLE
append subtarget name to all platforms; rev2

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -25,7 +25,12 @@ builder_names = [
     "ar71xx_mikrotik",
     "mpc85xx",
     "ramips",
-    "x86"
+    "x86",
+    "ar71xx-generic",
+    "ar71xx-mikrotik",
+    "mpc85xx-generic",
+    "ramips-generic",
+    "x86-generic",
     ]
 
 c['schedulers'] = []


### PR DESCRIPTION
When subtarget support was introduce, it was only used for target ar71xx_mikrotik
and none of the old targets e.g. ar71xx was renamed including it's subtarget.
Every platform has a subtarget, even when it's generic.
Rename those platform into $TARGET-$SUBTARGET. As there are some SUBTARGETS with
"_" in name, using "-" will not require complex parsing.
LEDE requires to know the subtarget, because it has a different bin/ directory
layout. It uses /bin/$TARGET/$SUBTARGET/foobar.sysupgrade.squashfs.bin

ar71xx -> ar71xx-generic
mpc85xx -> mpc85xx-generic
ramips -> ramip-mt7620
x86 -> x86-generic

also rename current files to new syntax
ar71xx_mikrotik -> ar71xx-mikrotik

To stay compatible with the current buildscripts this just adds the new / renamed
Tagets for a transitioning-period.