### PR TITLE
add env "IS_BUILDBOT" to make

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -111,6 +111,7 @@ def cmd_make_command(props):
         command.extend(['-j', '2'])
     command.extend(["TARGET=" + props.getProperty('buildername')])
     command.extend(["VERSION_REPO=" + repo_url(props)])
+    command.extend(['IS_BUILDBOT=yes'])
     return command
 
 


### PR DESCRIPTION
this gives the environment "IS_BUILDBOT" to the make parameters.

This is used in firmware Makefile to have the knowledge if running on a buildslave. By this the build_dir can be deleted after build to free some diskspace (see https://github.com/freifunk-berlin/firmware/commit/0ce969e2053bbe95a97a8a4e79cb5d34d78927ce - Makefile: add BUILD env "IS_BUILDBOT")