### PR TITLE
add targets ramips-mt7621 & x86-xen_domU

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -30,7 +30,9 @@ builder_names = [
     "ar71xx-mikrotik",
     "mpc85xx-generic",
     "ramips-mt7620",
+    "ramips-mt7621",
     "x86-generic",
+    "x86-xen_domu",
     ]
 
 c['schedulers'] = []


### PR DESCRIPTION
to build for EdgeRouter X and Xen-VMs