### PR TITLE
buildbot: add TARGET ramips-mt76x8

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -26,6 +26,7 @@ builder_names = [
     "mpc85xx-generic",
     "ramips-mt7620",
     "ramips-mt7621",
+    "ramips-mt76x8",
     "x86-generic",
     ]
 


### PR DESCRIPTION
this new TARGET has been added to the firmware master-branch
after https://github.com/freifunk-berlin/firmware/pull/526 has been merged