### PR TITLE
Add TARGET ar71xx-tiny

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -23,6 +23,7 @@ from buildbot.schedulers.timed import Periodic
 builder_names = [
     "ar71xx-generic",
     "ar71xx-mikrotik",
+    "ar71xx-tiny",
     "mpc85xx-generic",
     "ramips-mt7620",
     "ramips-mt7621",


### PR DESCRIPTION
This new TARGET ar71xx-tiny is available since
https://github.com/freifunk-berlin/firmware/pull/526/commits/621a4467094624a70f82086789dcf3634853bcc5