### PR TITLE
restart buildbot after config-change

### DIFF
--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "sudo service restart buildbot"


### PR DESCRIPTION
according to https://git-scm.com/docs/githooks#_post_merge the post-merge hook is called after "git pull" ran to update the local repo. As this script is not in the default "git-hooks"- directory ($GIT_DIR/hooks) it can be activated by one of:
* set "core.hooksPath" to "git-hooks"
* symlink the script to "$GIT_DIR/hooks/post-merge"

This post-merge script will restart the buildbot-daemon to apply the new config provided in the repo.
This can be combined with a cronjob to do "git pull" and we have some git-controlled autodeploy.