### PR TITLE
add new target "ath79-generic"

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -23,6 +23,7 @@ from buildbot.schedulers.timed import Periodic
 builder_names = [
     "ar71xx-generic",
     "ar71xx-mikrotik",
+    "ath79-generic",
     "mpc85xx-generic",
     "ramips-mt7620",
     "ramips-mt7621",


### PR DESCRIPTION
This is a new target that will replace ar71xx mid-term. See http://lists.infradead.org/pipermail/lede-dev/2018-May/012152.html and firmware-commit https://github.com/freifunk-berlin/firmware/commit/2e83d035e55e94e92ec68631ce16e00a2790e35f