### PR TITLE
build Target mvebu-cortexa9

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -25,6 +25,7 @@ builder_names = [
     "ar71xx-mikrotik",
     "ath79-generic",
     "mpc85xx-generic",
+    "mvebu-cortexa9",
     "ramips-mt7620",
     "ramips-mt7621",
     "ramips-mt76x8",


### PR DESCRIPTION
This enables building of the CortexA9 target added in https://github.com/freifunk-berlin/firmware/pull/529