### PR TITLE
build target ipq40xx-generic

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -25,6 +25,7 @@ builder_names = [
     "ar71xx-mikrotik",
     "ath79-generic",
     "mpc85xx-generic",
+    "ipq40xx-generic",
     "ramips-mt7620",
     "ramips-mt7621",
     "ramips-mt76x8",


### PR DESCRIPTION
This will bring support for the GliNet B1300 added in https://github.com/freifunk-berlin/firmware/commit/3d5fa62f2cc585211d10cc1214e08611e13feb2d (https://github.com/freifunk-berlin/firmware/issues/633)