### PR TITLE
Atomic make / build in 2 phases

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -115,8 +115,14 @@ def cmd_make_command(props, maketarget="all"):
     return command
 
 
-cmd_make = ShellCommand(
-    command=cmd_make_command,
+cmd_make_firmware = ShellCommand(
+    command=cmd_make_command("firmware"),
+    workdir="build/firmware",
+    haltOnFailure=True
+    )
+
+cmd_make_images = ShellCommand(
+    command=cmd_make_command("images"),
     workdir="build/firmware",
     haltOnFailure=True
     )
@@ -178,7 +184,8 @@ cmd_create_release_dir = MasterShellCommand(
 
 factory = BuildFactory([
     cmd_checkoutSource,
-    cmd_make,
+    cmd_make_firmware,
+    cmd_make_images,
     cmd_mastermkdir,
     cmd_uploadPackages,
     cmd_masterchmod,

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -101,7 +101,7 @@ def repo_url(props):
 
 
 @renderer
-def cmd_make_command(props):
+def cmd_make_command(props, maketarget="all"):
     command = ['nice', 'make']
     cpus = props.getProperty('cpus_per_build')
     if cpus:
@@ -111,6 +111,7 @@ def cmd_make_command(props):
     command.extend(["TARGET=" + props.getProperty('buildername')])
     command.extend(["VERSION_REPO=" + repo_url(props)])
     command.extend(['IS_BUILDBOT=yes'])
+    command.extend([maketarget])
     return command
 
 


### PR DESCRIPTION
This PR splits the buildprocess into 2 phases. The advanteges are:
* smaller logfile
* quick overview which phase of the build failed (OpenWrt or Imagebuilder)