### PR TITLE
master: ensure target-dir exists

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -124,10 +124,19 @@ upload_directory = Interpolate(
     "/usr/local/src/www/htdocs/buildbot/unstable/%(prop:buildername)s/%(prop:buildnumber)s/"
     )
 
-cmd_mastermkdir = MasterShellCommand(
+cmd_mastermkdir_target = MasterShellCommand(
+    targetdir = os.path.normpath(os.path.join(upload_directory, os.pardir))
+    if not os.path.exists(targetdir):
+        command=[
+            "mkdir",
+            "--mode=a+rx",
+            targetdir
+        ]
+    )
+
+cmd_mastermkdir_build = MasterShellCommand(
     command=[
         "mkdir",
-        "-p",
         "--mode=a+rx",
         upload_directory
     ])
@@ -178,7 +187,8 @@ cmd_create_release_dir = MasterShellCommand(
 factory = BuildFactory([
     cmd_checkoutSource,
     cmd_make,
-    cmd_mastermkdir,
+    cmd_mastermkdir_target,
+    cmd_mastermkdir_build,
     cmd_uploadPackages,
     cmd_masterchmod,
     cmd_create_release_dir,


### PR DESCRIPTION
* add step ```cmd_mastermkdir_target```, which checks if the target-specific directory exists and creates it on demand
* as the target-specific directory will be created, we can drop the ```-p``` parameter from the make command

This should prevent 403-errors for new targets (https://github.com/freifunk-berlin/buildbot/issues/50)