### PR TITLE
use "firmware.berlin.freifunk.net" as repo-host

### DIFF
--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -82,7 +82,7 @@ feed_conf_interpolate = Interpolate(
     ),
 
 def repo_url(props):
-    base_url = "http://buildbot.berlin.freifunk.net/buildbot"
+    base_url = "http://firmware.berlin.freifunk.net"
     branch = props.getProperty("branch")
     target = props.getProperty("buildername")
     is_release_branch = re.match("\d+\.\d+\.\d+$", branch)


### PR DESCRIPTION
Since some time the hostname "firmware.berlin.freifunk.net" is an alias for "buildbot.berlin.freifunk.net/buildbot" and is an easy shorthand to access the files-repo. Beside this, the separate hostname is more portable .