### PR TITLE
Migrate Falter-stuff to freifunk-berlin organisation

### DIFF
--- a/masters/master/buildsteps_feed.py
+++ b/masters/master/buildsteps_feed.py
@@ -14,6 +14,7 @@ feed_checkoutSource = Git(
     branch="master",   # this can get changed by html.WebStatus.change_hook()
                        # by notification from GitHub of a commit
     workdir="build",
+    alwaysUseLatest=True,
     mode='full'
     )
 

--- a/masters/master/buildsteps_feed.py
+++ b/masters/master/buildsteps_feed.py
@@ -18,15 +18,6 @@ feed_checkoutSource = Git(
     mode='full'
     )
 
-upload_dir = Interpolate("/usr/local/src/www/htdocs/buildbot/feed/new/%(prop:buildername)s/")
-feed_master_empty_dir = MasterShellCommand(
-    name="clear upload dir",
-    command=[
-        "rm",
-        "-rf",
-        upload_dir
-        ]
-)
 
 feed_create_tmpdir = ShellCommand(
     name="create tmp dir",
@@ -54,6 +45,7 @@ feed_make = ShellCommand(
     )
 
 
+upload_dir = Interpolate("/usr/local/src/www/htdocs/buildbot/feed/new/%(prop:buildername)s-%(prop:revision)s/")
 feed_mastermkdir = MasterShellCommand(
     name="create upload dir",
     command=[
@@ -99,7 +91,6 @@ feed_cleanup_tmp = RemoveDirectory(
 
 feed_factory = BuildFactory([
     feed_checkoutSource,
-    feed_master_empty_dir,
     feed_create_tmpdir,
     feed_make,
     feed_mastermkdir,

--- a/masters/master/buildsteps_feed.py
+++ b/masters/master/buildsteps_feed.py
@@ -113,7 +113,7 @@ feed_factory = BuildFactory([
 def create_feed_builder(builder_name):
     return BuilderConfig(
         name=builder_name,
-        workernames=['ionos-worker01'],
+        workernames=['ionos-worker01', 'ionos-worker02'],
         factory=feed_factory
     )
 

--- a/masters/master/buildsteps_feed.py
+++ b/masters/master/buildsteps_feed.py
@@ -1,0 +1,114 @@
+from buildbot.process.factory import BuildFactory
+from buildbot.config import BuilderConfig
+from buildbot.steps.source.git import Git
+from buildbot.steps.shell import ShellCommand
+from buildbot.steps.transfer import DirectoryUpload
+from buildbot.steps.master import MasterShellCommand
+from buildbot.process.properties import Interpolate, renderer
+from buildbot.steps.worker import RemoveDirectory
+from datetime import date
+
+
+feed_checkoutSource = Git(
+    repourl='git://github.com/Freifunk-Spalter/repo_builder',
+    branch="master",   # this can get changed by html.WebStatus.change_hook()
+                       # by notification from GitHub of a commit
+    workdir="build/falter-repo-builder",
+    mode='full'
+    )
+
+feed_create_tmpdir = ShellCommand(
+    name="create tmp dir",
+    command=[
+    "mkdir",
+    "-p",
+    "tmp"
+    ])
+
+@renderer
+def feed_make_command(props):
+    command = ['nice',
+	'./build_all_targets',
+	'19.07.5',
+        Interpolate('src-git falter https://github.com/Freifunk-Spalter/packages.git;%(prop:buildername)s'),
+        Interpolate('%(prop:builddir)s/tmp'),
+        'build_parallel'
+        ]
+    return command
+
+feed_make = ShellCommand(
+    name="build feed",
+    command=feed_make_command,
+    workdir="build/falter-repo-builder",
+    haltOnFailure=True
+    )
+
+upload_dir = Interpolate("/usr/local/src/www/htdocs/buildbot/feed/new/%(prop:buildername)s/")
+feed_master_empty_dir = MasterShellCommand(
+    name="clear upload dir",
+    command=[
+        "rm",
+        "-rf",
+        upload_dir
+        ]
+)
+
+feed_mastermkdir = MasterShellCommand(
+    name="create upload dir",
+    command=[
+        "mkdir",
+        "-p",
+        "--mode=a+rx",
+        upload_dir
+        ]
+)
+
+worker_src_dir = Interpolate("%(prop:builddir)s/tmp/")
+feed_uploadPackages = DirectoryUpload(
+    workersrc=worker_src_dir,
+    masterdest=upload_dir
+    )
+
+feed_masterchmod = MasterShellCommand(
+    name="chmod upload dir",
+    command=[
+        "chmod",
+        "-R",
+        "o+rX",
+        upload_dir
+    ])
+
+feed_sign_packages = MasterShellCommand(
+    name="sign packages",
+    command=[
+        "/usr/local/src/sign_packages.sh",
+        upload_dir
+        ]
+)
+
+feed_cleanup = RemoveDirectory(
+    dir="build/falter-repo-builder",
+    alwaysRun=True
+    )
+
+feed_factory = BuildFactory([
+    feed_checkoutSource,
+    feed_create_tmpdir,
+    feed_make,
+    feed_master_empty_dir,
+    feed_mastermkdir,
+    feed_uploadPackages,
+    feed_masterchmod,
+    feed_sign_packages,
+    feed_cleanup
+    ])
+
+def create_feed_builder(builder_name):
+    return BuilderConfig(
+        name=builder_name,
+        workernames=['ionos-worker01'],
+        factory=feed_factory
+    )
+
+if __name__ == "__main__":
+    pass

--- a/masters/master/buildsteps_feed.py
+++ b/masters/master/buildsteps_feed.py
@@ -43,7 +43,7 @@ feed_create_tmpdir = ShellCommand(
 def feed_make_command(props):
     command = ['nice',
 	'./build_all_targets',
-    Interpolate('src-git falter https://github.com/Freifunk-Spalter/packages.git;%(prop:buildername)s'),
+    Interpolate('src-git falter https://github.com/Freifunk-Spalter/packages.git^%(prop:revision)s'),
     Interpolate('%(prop:builddir)s/tmp'),
     'build_parallel'
         ]

--- a/masters/master/buildsteps_image.py
+++ b/masters/master/buildsteps_image.py
@@ -33,9 +33,9 @@ feed_conf_interpolate = Interpolate(
 @renderer
 def cmd_make_command(props):
     command = ['nice', './build_falter']
-    command.extend(["all"])
-    command.extend(["19.07"])
-    command.extend([props.getProperty('buildername')])
+    command.extend(["-p", "all"])
+    command.extend(["-v", "19.07"])
+    command.extend(["-t", props.getProperty('buildername')])
     return command
 
 

--- a/masters/master/buildsteps_image.py
+++ b/masters/master/buildsteps_image.py
@@ -14,7 +14,7 @@ from datetime import date
 
 
 # If we trigger the build via web UI, this is the version that gets built
-defaultFalterVersion = "1.1.0"
+defaultFalterVersion = "snapshot"
 
 
 
@@ -35,11 +35,19 @@ feed_conf_interpolate = Interpolate(
     "'s/\(packages_berlin\.git\^\)\([a-f0-9]\{40,40\}\)/\1%(prop:revision)s/'"
     )
 
+# this build wasn't triggered by feed-compilation
+def no_autobuild(step):
+    ver = step.getProperty("falterVersion") or None
+    if ver:
+        return False
+    else:
+        return True
 
-#set_property_falter_version = steps.SetProperty(
-#    property="defaultfalterVersion",
-#    value="1.1.0"
-#)
+set_property_falter_version = steps.SetProperty(
+    property="falterVersion",
+    value=defaultFalterVersion,
+    doStepIf=no_autobuild
+)
 
 @renderer
 def cmd_make_command(props):
@@ -136,7 +144,7 @@ cmd_rsync_release = MasterShellCommand(
 
 image_factory = BuildFactory([
     cmd_checkoutSource,
-    #set_property_falter_version,
+    set_property_falter_version,
     cmd_mastermkdir,
     cmd_master_clear_dir,
     cmd_make,

--- a/masters/master/buildsteps_image.py
+++ b/masters/master/buildsteps_image.py
@@ -54,7 +54,12 @@ def cmd_make_command(props):
     command = ['nice', './build_falter']
     command.extend(["-p", "all"])
     command.extend(["-v", props.getProperty('falterVersion', default=defaultFalterVersion)])
-    command.extend(["-t", props.getProperty('buildername')])
+    # slice build parameter from builder name
+    tmp_target = props.getProperty('buildername')
+    target = tmp_target.split('/')[0]
+    subtarget = tmp_target.split('/')[1]
+    command.extend(["-t", target])
+    command.extend(["-s", subtarget])
     return command
 
 
@@ -65,7 +70,6 @@ cmd_make = ShellCommand(
     haltOnFailure=True
     )
 
-#upload_directory = Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/"+ date.today().strftime("%Y-%m-%d") +"/%(prop:branch)s/")
 upload_directory = Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/%(prop:falterVersion:-1.1.0)s/")
 upload_dir_target = Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/%(prop:falterVersion:-1.1.0)s/*/%(prop:buildername)s/")
 

--- a/masters/master/buildsteps_image.py
+++ b/masters/master/buildsteps_image.py
@@ -19,7 +19,7 @@ defaultFalterVersion = "snapshot"
 
 
 def is_release_step(step):
-    branch = step.getProperty("branch") or 'was_not_set'
+    branch = step.getProperty("falterVersion") or 'was_not_set'
     return re.match(".*\d+\.\d+\.\d+$", branch)
 
 
@@ -70,8 +70,8 @@ cmd_make = ShellCommand(
     haltOnFailure=True
     )
 
-upload_directory = Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/%(prop:falterVersion:-1.1.0)s/")
-upload_dir_target = Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/%(prop:falterVersion:-1.1.0)s/*/%(prop:buildername)s/")
+upload_directory = Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/%(prop:falterVersion:-unknownVersion)s/")
+upload_dir_target = Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/%(prop:falterVersion:-unknownVersion)s/*/%(prop:buildername)s/")
 
 cmd_mastermkdir = MasterShellCommand(
     name="create upload-dir",
@@ -128,7 +128,7 @@ cmd_create_release_dir = MasterShellCommand(
         "mkdir",
         "-m755",
         "-p",
-        Interpolate("/usr/local/src/www/htdocs/buildbot/stable/%(prop:branch)s/")
+        Interpolate("/usr/local/src/www/htdocs/buildbot/stable/%(prop:falterVersion)s/")
         ],
     doStepIf=is_release_step
     )
@@ -140,7 +140,7 @@ cmd_rsync_release = MasterShellCommand(
         "-av",
         "--delete",
         upload_directory,
-        Interpolate("/usr/local/src/www/htdocs/buildbot/stable/%(prop:branch)s/%(prop:buildername)s")
+        Interpolate("/usr/local/src/www/htdocs/buildbot/stable/%(prop:falterVersion)s/%(prop:buildername)s")
         ],
     doStepIf=is_release_step
     )

--- a/masters/master/buildsteps_image.py
+++ b/masters/master/buildsteps_image.py
@@ -12,8 +12,11 @@ from buildbot.process.properties import Interpolate, renderer
 from buildbot.steps.worker import RemoveDirectory
 from datetime import date
 
-# If we trigger the build via web UI, this is the version that gets build
+
+# If we trigger the build via web UI, this is the version that gets built
 defaultFalterVersion = "1.1.0"
+
+
 
 def is_release_step(step):
     branch = step.getProperty("branch") or 'was_not_set'

--- a/masters/master/buildsteps_image.py
+++ b/masters/master/buildsteps_image.py
@@ -1,0 +1,120 @@
+from worker import build_worker, workernames
+import re
+
+from buildbot.process.factory import BuildFactory
+from buildbot.config import BuilderConfig
+from buildbot.steps.source.git import Git
+from buildbot.steps.shell import ShellCommand
+from buildbot.steps.transfer import DirectoryUpload
+from buildbot.steps.master import MasterShellCommand
+from buildbot.process.properties import Interpolate, renderer
+from buildbot.steps.worker import RemoveDirectory
+from datetime import date
+
+
+def is_release_step(step):
+    branch = step.getProperty("branch") or 'was_not_set'
+    return re.match(".*\d+\.\d+\.\d+$", branch)
+
+
+cmd_checkoutSource = Git(
+    repourl='git://github.com/Freifunk-Spalter/builter',
+    branch="master",   # this can get changed by html.WebStatus.change_hook()
+                       # by notification from GitHub of a commit
+    workdir="build/falter-builter",
+    mode='full'
+    )
+
+feed_conf_interpolate = Interpolate(
+    "'s/\(packages_berlin\.git\^\)\([a-f0-9]\{40,40\}\)/\1%(prop:revision)s/'"
+    )
+
+
+@renderer
+def cmd_make_command(props):
+    command = ['nice', './build_falter']
+    command.extend(["all"])
+    command.extend(["19.07"])
+    command.extend([props.getProperty('buildername')])
+    return command
+
+
+cmd_make = ShellCommand(
+    command=cmd_make_command,
+    workdir="build/falter-builter",
+    haltOnFailure=True
+    )
+
+upload_directory = Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/"+ date.today().strftime("%Y-%m-%d") +"/%(prop:branch)s/")
+
+cmd_mastermkdir = MasterShellCommand(
+    command=[
+        "mkdir",
+        "-p",
+        "--mode=a+rx",
+        upload_directory
+    ])
+
+image_worker_src_directory = Interpolate(
+    "falter-builter/firmwares/"
+)
+
+cmd_uploadPackages = DirectoryUpload(
+    workersrc=image_worker_src_directory,
+    masterdest=upload_directory
+    )
+
+cmd_masterchmod = MasterShellCommand(
+    command=[
+        "chmod",
+        "-R",
+        "o+rX",
+        upload_directory
+    ])
+
+cmd_cleanup = RemoveDirectory(
+    dir="build/falter-builter",
+    alwaysRun=True
+    )
+
+cmd_rsync_release = MasterShellCommand(
+    command=[
+        "rsync",
+        "-av",
+        "--delete",
+        upload_directory,
+        Interpolate("/usr/local/src/www/htdocs/buildbot/stable/%(prop:branch)s/%(prop:buildername)s")
+        ],
+    doStepIf=is_release_step
+    )
+
+cmd_create_release_dir = MasterShellCommand(
+    command=[
+        "mkdir",
+        "-m755",
+        "-p",
+        Interpolate("/usr/local/src/www/htdocs/buildbot/stable/%(prop:branch)s/")
+        ],
+    doStepIf=is_release_step
+    )
+
+image_factory = BuildFactory([
+    cmd_checkoutSource,
+    cmd_make,
+    cmd_mastermkdir,
+    cmd_uploadPackages,
+    cmd_masterchmod,
+    cmd_create_release_dir,
+    cmd_rsync_release,
+    cmd_cleanup
+    ])
+
+def create_builder_config(builder_name):
+    return BuilderConfig(
+        name=builder_name,
+        workernames=workernames,
+        factory=image_factory
+    )
+
+if __name__ == "__main__":
+    pass

--- a/masters/master/buildsteps_image.py
+++ b/masters/master/buildsteps_image.py
@@ -78,7 +78,7 @@ cmd_masterchmod = MasterShellCommand(
 cmd_masterchown = MasterShellCommand(
     name="make dir accessible",
     command=[
-        "chowm",
+        "chown",
         "-R",
         "www-data:buildbot",
         upload_directory

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -107,6 +107,7 @@ from buildbot.steps.transfer import DirectoryUpload
 from buildbot.steps.master import MasterShellCommand
 from buildbot.process.properties import Interpolate, renderer
 from buildbot.steps.worker import RemoveDirectory
+from datetime import date
 
 
 def is_release_step(step):
@@ -167,9 +168,8 @@ cmd_make = ShellCommand(
     haltOnFailure=True
     )
 
-upload_directory = Interpolate(
-    "/usr/local/src/www/htdocs/buildbot/unstable/%(prop:buildername)s/%(prop:buildnumber)s/"
-    )
+#upload_branch_name = Interpolate("%(prop:branch)s/")
+upload_directory = Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/"+ date.today().strftime("%Y-%m-%d") +"/%(prop:branch)s/")
 
 cmd_mastermkdir = MasterShellCommand(
     command=[

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -266,6 +266,7 @@ feed_checkoutSource = Git(
     )
 
 feed_create_tmpdir = ShellCommand(
+    name="create tmp dir",
     command=[
     "mkdir",
     "-p",
@@ -283,19 +284,31 @@ def feed_make_command(props):
     return command
 
 feed_make = ShellCommand(
+    name="build feed",
     command=feed_make_command,
     workdir="build/falter-repo-builder",
     haltOnFailure=True
     )
 
 upload_dir = Interpolate("/usr/local/src/www/htdocs/buildbot/feed/new/%(prop:branch)s/")
+feed_master_empty_dir = MasterShellCommand(
+    name="clear upload dir",
+    command=[
+        "rm",
+        "-rf",
+        upload_dir
+        ]
+)
+
 feed_mastermkdir = MasterShellCommand(
+    name="create upload dir",
     command=[
         "mkdir",
         "-p",
         "--mode=a+rx",
         upload_dir
-    ])
+        ]
+)
 
 worker_src_dir = Interpolate("%(prop:builddir)s/tmp/")
 feed_uploadPackages = DirectoryUpload(
@@ -304,12 +317,36 @@ feed_uploadPackages = DirectoryUpload(
     )
 
 feed_masterchmod = MasterShellCommand(
+    name="chmod upload dir",
     command=[
         "chmod",
         "-R",
         "o+rX",
         upload_dir
     ])
+
+feed_sign_packages = MasterShellCommand(
+    name="sign packages",
+    command=[
+        "/usr/local/src/sign_packages.sh",
+        upload_dir
+        ]
+)
+
+
+#def feed_branch_stable(step):
+#    branch = step.getProperty("branch") or 'was_not_set'
+#    return re.match(".*\d+\.\d+$", branch)
+
+# TODO: Nicht der branch vom repo-builder, sondern der branch aus der githook (package-repo)
+#stable_dir = Interpolate("/usr/local/src/www/htdocs/buildbot/feed/%(prop:branch)s/")
+#feed_move_feed_stable = MasterShellCommand(
+#    command=[
+#        "rm", "-rf", stable_dir, "&&",
+#        "mv", upload_dir, stable_dir
+#    ],
+#    doStepIf=feed_branch_stable
+#)
 
 feed_cleanup = RemoveDirectory(
     dir="build/falter-repo-builder",
@@ -320,9 +357,11 @@ feed_factory = BuildFactory([
     feed_checkoutSource,
     feed_create_tmpdir,
     feed_make,
+    feed_master_empty_dir,
     feed_mastermkdir,
     feed_uploadPackages,
     feed_masterchmod,
+    feed_sign_packages,
     feed_cleanup
     ])
 

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -111,7 +111,7 @@ from buildbot.steps.worker import RemoveDirectory
 
 def is_release_step(step):
     branch = step.getProperty("branch") or 'was_not_set'
-    return re.match("\d+\.\d+\.\d+$", branch)
+    return re.match(".*\d+\.\d+\.\d+$", branch)
 
 
 cmd_checkoutSource = Git(

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -61,9 +61,18 @@ builder_names = [
     "zynq"
     ]
 
-feed_builders = [
-    "build_falter_feed"
+# define the branches, that will be listened to
+# and built by buildbot
+feed_branches = [
+    "master",
+    "openwrt-19.07"
     ]
+# builder names
+feed_builders = []
+for branch in feed_branches:
+    buildername = "falter-packagefeed_"+branch
+    feed_builders.append(buildername)
+
 
 
 c['schedulers'] = []
@@ -277,10 +286,10 @@ feed_create_tmpdir = ShellCommand(
 def feed_make_command(props):
     command = ['nice',
 	'./build_all_targets',
-	'19.07.5',
-	'src-git falter https://github.com/Freifunk-Spalter/packages.git',
-	Interpolate('%(prop:builddir)s/tmp')
-	]
+	'19.07.5']
+	feed_branch = util.Property('buildername').split(sep='_')[-1]
+	command.extend('src-git falter https://github.com/Freifunk-Spalter/packages.git;'+feed_branch)
+	command.extend(Interpolate('%(prop:builddir)s/tmp'))
     return command
 
 feed_make = ShellCommand(
@@ -290,7 +299,7 @@ feed_make = ShellCommand(
     haltOnFailure=True
     )
 
-upload_dir = Interpolate("/usr/local/src/www/htdocs/buildbot/feed/new/%(prop:branch)s/")
+upload_dir = "/usr/local/src/www/htdocs/buildbot/feed/new/" + util.Property('buildername').split(sep='_')[-1]
 feed_master_empty_dir = MasterShellCommand(
     name="clear upload dir",
     command=[

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -60,6 +60,7 @@ builder_names = [
 feed_builders = [
     "master",
     "openwrt-19.07",
+    "openwrt-21.02",
     "feed_testbranch"
     ]
 
@@ -101,6 +102,15 @@ c['schedulers'].append(SingleBranchScheduler(
             branch="openwrt-19.07"),
         treeStableTimer=300,
         builderNames=["openwrt-19.07"]
+    )
+)
+
+c['schedulers'].append(SingleBranchScheduler(
+        name="build_packagefeed_openwrt2102",
+        change_filter=filter.ChangeFilter(
+            branch="openwrt-21.02"),
+        treeStableTimer=300,
+        builderNames=["openwrt-21.02"]
     )
 )
 

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -110,8 +110,7 @@ from buildbot.steps.worker import RemoveDirectory
 
 
 def is_release_step(step):
-    branch = step.build.getProperty("branch")
-    print("\n\nThe branch is: " + branch + "\n\n")
+    branch = step.getProperty("branch") or 'was_not_set'
     return re.match("\d+\.\d+\.\d+$", branch)
 
 

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -246,8 +246,13 @@ c['builders'] = list(map(create_builder_config, builder_names))
 
 c['www'] = dict(
 	port=8010,
-	plugins=dict(waterfall_view={}, console_view={}, grid_view={})#,
-	#change_hook_dialects={ 'github': { 'secret': 'c3600bf6160cf2c8536b260111b97a339', 'strict': True } },
+	plugins=dict(waterfall_view={}, console_view={}, grid_view={}),
+	change_hook_dialects={
+    'github': {
+        'secret': 'c3600bf6160cf2c8536b260111b97a339',
+        'strict': True
+        }
+    }
 )
 
 c['protocols'] = { 'pb': { 'port': 9989 } }

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -59,7 +59,8 @@ builder_names = [
 # builder-names correspond to branches in falter-packages-repository.
 feed_builders = [
     "master",
-    "openwrt-19.07"
+    "openwrt-19.07",
+    "feed_testbranch"
     ]
 
 

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -61,8 +61,13 @@ builder_names = [
     "zynq"
     ]
 
+feed_builders = [
+    "build_falter_feed"
+    ]
+
+
 c['schedulers'] = []
-c['schedulers'].append(
+"""c['schedulers'].append(
     SingleBranchScheduler(
         name="falter githook",
         change_filter=filter.ChangeFilter(
@@ -72,6 +77,16 @@ c['schedulers'].append(
         treeStableTimer=10,
         builderNames=builder_names
     )
+)"""
+
+c['schedulers'].append(SingleBranchScheduler(
+        name="build_packagefeed",
+        change_filter=filter.ChangeFilter(
+            project='/Freifunk-Spalter/packages',
+            branch=['master','openwrt-19.07']),
+        treeStableTimer=300,
+        builderNames=feed_builders
+        )
 )
 
 c['schedulers'].append(Periodic(
@@ -117,7 +132,7 @@ def is_release_step(step):
 
 cmd_checkoutSource = Git(
     repourl='git://github.com/Freifunk-Spalter/builter',
-    branch="feature/build_all_packagesets",   # this can get changed by html.WebStatus.change_hook()
+    branch="master",   # this can get changed by html.WebStatus.change_hook()
                        # by notification from GitHub of a commit
     workdir="build/falter-builter",
     mode='full'
@@ -222,7 +237,7 @@ cmd_create_release_dir = MasterShellCommand(
     doStepIf=is_release_step
     )
 
-factory = BuildFactory([
+image_factory = BuildFactory([
     cmd_checkoutSource,
     cmd_make,
     cmd_mastermkdir,
@@ -233,16 +248,95 @@ factory = BuildFactory([
     cmd_cleanup
     ])
 
-
 def create_builder_config(builder_name):
     return BuilderConfig(
         name=builder_name,
         workernames=slavenames,
-        factory=factory
+        factory=image_factory
+    )
+
+
+
+feed_checkoutSource = Git(
+    repourl='git://github.com/Freifunk-Spalter/repo_builder',
+    branch="master",   # this can get changed by html.WebStatus.change_hook()
+                       # by notification from GitHub of a commit
+    workdir="build/falter-repo-builder",
+    mode='full'
+    )
+
+feed_create_tmpdir = ShellCommand(
+    command=[
+    "mkdir",
+    "-p",
+    "tmp"
+    ])
+
+@renderer
+def feed_make_command(props):
+    command = ['nice',
+	'./build_all_targets',
+	'19.07.5',
+	'src-git falter https://github.com/Freifunk-Spalter/packages.git',
+	Interpolate('%(prop:builddir)s/tmp')
+	]
+    return command
+
+feed_make = ShellCommand(
+    command=feed_make_command,
+    workdir="build/falter-repo-builder",
+    haltOnFailure=True
+    )
+
+upload_dir = Interpolate("/usr/local/src/www/htdocs/buildbot/feed/new/%(prop:branch)s/")
+feed_mastermkdir = MasterShellCommand(
+    command=[
+        "mkdir",
+        "-p",
+        "--mode=a+rx",
+        upload_dir
+    ])
+
+worker_src_dir = Interpolate("%(prop:builddir)s/tmp/")
+feed_uploadPackages = DirectoryUpload(
+    workersrc=worker_src_dir,
+    masterdest=upload_dir
+    )
+
+feed_masterchmod = MasterShellCommand(
+    command=[
+        "chmod",
+        "-R",
+        "o+rX",
+        upload_dir
+    ])
+
+feed_cleanup = RemoveDirectory(
+    dir="build/falter-repo-builder",
+    alwaysRun=True
+    )
+
+feed_factory = BuildFactory([
+    feed_checkoutSource,
+    feed_create_tmpdir,
+    feed_make,
+    feed_mastermkdir,
+    feed_uploadPackages,
+    feed_masterchmod,
+    feed_cleanup
+    ])
+
+def create_feed_builder(builder_name):
+    return BuilderConfig(
+        name=builder_name,
+        workernames=slavenames,
+        factory=feed_factory
     )
 
 
 c['builders'] = list(map(create_builder_config, builder_names))
+c['builders'].extend(list(map(create_feed_builder, feed_builders)))
+
 
 c['www'] = dict(
 	port=8010,

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -22,24 +22,52 @@ from buildbot.changes import filter
 from buildbot.schedulers.timed import Periodic
 
 builder_names = [
-    "ar71xx-generic",
-    "ar71xx-mikrotik",
-    "ath79-generic",
-    "mpc85xx-generic",
-    "ipq40xx-generic",
-    "ramips-mt7620",
-    "ramips-mt7621",
-    "ramips-mt76x8",
-    "x86-generic",
+    "apm821xx",
+    "ar71xx",
+    "arc770",
+    "archs38",
+    "armvirt",
+    "at91",
+    "ath25",
+    "ath79",
+    "bcm53xx",
+    "brcm2708",
+    "brcm47xx",
+    "brcm63xx",
+    "cns3xxx",
+    "gemini",
+    "imx6",
+    "ipq40xx",
+    "ipq806x",
+    "kirkwood",
+    "lantiq",
+    "layerscape",
+    "malta",
+    "mediatek",
+    "mpc85xx",
+    "mvebu",
+    "mxs",
+    "octeon",
+    "octeontx",
+    "omap",
+    "oxnas",
+    "pistachio",
+    "ramips",
+    "rb532",
+    "samsung",
+    "sunxi",
+    "tegra",
+    "x86",
+    "zynq"
     ]
 
 c['schedulers'] = []
 c['schedulers'].append(
     SingleBranchScheduler(
-        name="berlin githook",
+        name="falter githook",
         change_filter=filter.ChangeFilter(
             branch_re='.*',
-            repository='https://github.com/Freifunk-Spalter/falter-buildsystem'
+            repository='https://github.com/Freifunk-Spalter/builter'
             ),
         treeStableTimer=10,
         builderNames=builder_names
@@ -48,9 +76,17 @@ c['schedulers'].append(
 
 c['schedulers'].append(Periodic(
     name="weekly",
-    branch="master",
+    branch="feature/build_all_packagesets",
     builderNames=builder_names,
     periodicBuildTimer=7*24*60*60
+    )
+)
+
+c['schedulers'].append(Periodic(
+    name="daily_master",
+    branch="feature/build_all_packagesets",
+    builderNames=builder_names,
+    periodicBuildTimer=24*60*60
     )
 )
 
@@ -75,14 +111,15 @@ from buildbot.steps.worker import RemoveDirectory
 
 def is_release_step(step):
     branch = step.build.getProperty("branch")
+    print("\n\nThe branch is: " + branch + "\n\n")
     return re.match("\d+\.\d+\.\d+$", branch)
 
 
 cmd_checkoutSource = Git(
-    repourl='git://github.com/Freifunk-Spalter/falter-buildsystem.git',
-    branch="falter-19.07",   # this can get changed by html.WebStatus.change_hook()
+    repourl='git://github.com/Freifunk-Spalter/builter',
+    branch="feature/build_all_packagesets",   # this can get changed by html.WebStatus.change_hook()
                        # by notification from GitHub of a commit
-    workdir="build/falter-buildsystem",
+    workdir="build/falter-builter",
     mode='full'
     )
 
@@ -111,21 +148,23 @@ def repo_url(props):
 
 @renderer
 def cmd_make_command(props):
-    command = ['nice', 'make']
-    cpus = props.getProperty('cpus_per_build')
-    if cpus:
-        command.extend(['-j', str(cpus+1)])
-    else:
-        command.extend(['-j', '2'])
-    command.extend(["TARGET=" + props.getProperty('buildername')])
-    command.extend(["VERSION_REPO=" + repo_url(props)])
-    command.extend(['IS_BUILDBOT=yes'])
+    command = ['nice', './build_falter']
+    #cpus = props.getProperty('cpus_per_build')
+    #if cpus:
+    #    command.extend(['-j', str(cpus+1)])
+    #else:
+    #    command.extend(['-j', '2'])
+    command.extend(["all"])
+    command.extend(["19.07"])
+    command.extend([props.getProperty('buildername')])
+    #command.extend(["VERSION_REPO=" + repo_url(props)])
+    #command.extend(['IS_BUILDBOT=yes'])
     return command
 
 
 cmd_make = ShellCommand(
     command=cmd_make_command,
-    workdir="build/falter-buildsystem",
+    workdir="build/falter-builter",
     haltOnFailure=True
     )
 
@@ -142,7 +181,7 @@ cmd_mastermkdir = MasterShellCommand(
     ])
 
 slave_src_directory = Interpolate(
-    "falter-buildsystem/firmwares/%(prop:buildername)s/"
+    "falter-builter/firmwares/"
 )
 
 cmd_uploadPackages = DirectoryUpload(
@@ -159,7 +198,7 @@ cmd_masterchmod = MasterShellCommand(
     ])
 
 cmd_cleanup = RemoveDirectory(
-    dir="build/falter-buildsystem",
+    dir="build/falter-builter",
     alwaysRun=True
     )
 

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -159,6 +159,13 @@ c['schedulers'].append(
     )
 )
 
+# triggerable schedulers for releases
+c['schedulers'].append(
+    schedulers.Triggerable(
+        name="trigger_release",
+        builderNames=targets_2102
+    )
+)
 
 
 ################

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -87,13 +87,30 @@ c['schedulers'] = []
 )"""
 
 c['schedulers'].append(SingleBranchScheduler(
-        name="build_packagefeed",
+        name="build_packagefeed_master",
         change_filter=filter.ChangeFilter(
-            project='/Freifunk-Spalter/packages',
-            branch=['master','openwrt-19.07']),
+            branch="master"),
         treeStableTimer=300,
-        builderNames=feed_builders
-        )
+        builderNames=["master"]
+    )
+)
+
+c['schedulers'].append(SingleBranchScheduler(
+        name="build_packagefeed_openwrt1907",
+        change_filter=filter.ChangeFilter(
+            branch="openwrt-19.07"),
+        treeStableTimer=300,
+        builderNames=["openwrt-19.07"]
+    )
+)
+
+c['schedulers'].append(SingleBranchScheduler(
+        name="build_packagefeed_testbranch",
+        change_filter=filter.ChangeFilter(
+            branch="feed_testbranch"),
+        treeStableTimer=60,
+        builderNames=["feed_testbranch"]
+    )
 )
 
 c['schedulers'].append(Periodic(

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -61,17 +61,11 @@ builder_names = [
     "zynq"
     ]
 
-# define the branches, that will be listened to
-# and built by buildbot
-feed_branches = [
+# define the branche-names, that we want to build a package repo from
+feed_builders = [
     "master",
     "openwrt-19.07"
     ]
-# builder names
-feed_builders = []
-for branch in feed_branches:
-    buildername = "falter-packagefeed_"+branch
-    feed_builders.append(buildername)
 
 
 
@@ -116,10 +110,18 @@ c['schedulers'].append(Periodic(
 
 c['schedulers'].append(
 	ForceScheduler(
-        name="force",
+        name="force_building_images",
         builderNames=builder_names
         )
 	)
+
+c['schedulers'].append(
+    ForceScheduler(
+        name="force_building_packagefeed",
+        builderNames=feed_builders
+        )
+    )
+
 
 
 # BUILDERS
@@ -300,7 +302,7 @@ feed_make = ShellCommand(
     haltOnFailure=True
     )
 
-upload_dir = "/usr/local/src/www/htdocs/buildbot/feed/new/" + util.Property('buildername').split(sep='_')[-1]
+upload_dir = Interpolate("/usr/local/src/www/htdocs/buildbot/feed/new/%(prop:buildername)s/")
 feed_master_empty_dir = MasterShellCommand(
     name="clear upload dir",
     command=[

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -61,7 +61,8 @@ targets_2102 = [
 feed_builders = [
     "master",
     "openwrt-21.02",
-    "feed_testbranch"
+    "upstream/21.02-perry"
+    "feed_testbranch",
     ]
 
 
@@ -104,6 +105,16 @@ c['schedulers'].append(SingleBranchScheduler(
             branch="feed_testbranch"),
         treeStableTimer=300,
         builderNames=["feed_testbranch"]
+    )
+)
+
+# compile perrys personal branch
+c['schedulers'].append(SingleBranchScheduler(
+        name="build_packagefeed_perry",
+        change_filter=filter.ChangeFilter(
+            branch="upstream/21.02-perry"),
+        treeStableTimer=30,
+        builderNames=["upstream/21.02-perry"]
     )
 )
 

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -17,6 +17,7 @@ c['workers'] = build_slaves
 
 # SCHEDULERS
 from buildbot.schedulers.basic import SingleBranchScheduler
+from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.changes import filter
 from buildbot.schedulers.timed import Periodic
 
@@ -52,6 +53,14 @@ c['schedulers'].append(Periodic(
     periodicBuildTimer=7*24*60*60
     )
 )
+
+c['schedulers'].append(
+	ForceScheduler(
+        name="force",
+        builderNames=builder_names
+        )
+	)
+
 
 # BUILDERS
 from buildbot.process.factory import BuildFactory

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -15,6 +15,14 @@ from worker import build_worker, workernames
 c['workers'] = build_worker
 
 
+# targets for snapshots
+snapshot_targets = [
+    "ath79",
+    "ipq40xx",
+    "mpc85xx",
+    "ramips"
+]
+
 # builder-names correspond to openwrt-targets
 builder_names = [
     "apm821xx",
@@ -24,7 +32,6 @@ builder_names = [
     "armvirt",
     "at91",
     "ath25",
-    "ath79",
     "bcm53xx",
     "brcm2708",
     "brcm47xx",
@@ -32,14 +39,12 @@ builder_names = [
     "cns3xxx",
     "gemini",
     "imx6",
-    "ipq40xx",
     "ipq806x",
     "kirkwood",
     "lantiq",
     "layerscape",
     "malta",
     "mediatek",
-    "mpc85xx",
     "mvebu",
     "mxs",
     "octeon",
@@ -47,14 +52,13 @@ builder_names = [
     "omap",
     "oxnas",
     "pistachio",
-    "ramips",
     "rb532",
     "samsung",
     "sunxi",
     "tegra",
     "x86",
     "zynq"
-    ]
+    ] + snapshot_targets
 
 # builder-names correspond to branches in falter-packages-repository.
 feed_builders = [
@@ -73,6 +77,7 @@ from buildbot.schedulers.basic import SingleBranchScheduler
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.changes import filter
 from buildbot.schedulers.timed import Periodic
+from buildbot.plugins import schedulers, steps, util
 
 c['schedulers'] = []
 """c['schedulers'].append(
@@ -152,6 +157,14 @@ c['schedulers'].append(
         builderNames=feed_builders
         )
     )
+
+# triggerable schedulers for snapshots
+c['schedulers'].append(
+    schedulers.Triggerable(
+        name="trigger_snapshots",
+        builderNames=snapshot_targets
+    )
+)
 
 
 

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -96,7 +96,7 @@ c['schedulers'].append(SingleBranchScheduler(
         name="build_packagefeed_master",
         change_filter=filter.ChangeFilter(
             branch="master"),
-        treeStableTimer=300,
+        treeStableTimer=600,
         builderNames=["master"]
     )
 )
@@ -105,7 +105,7 @@ c['schedulers'].append(SingleBranchScheduler(
         name="build_packagefeed_openwrt1907",
         change_filter=filter.ChangeFilter(
             branch="openwrt-19.07"),
-        treeStableTimer=300,
+        treeStableTimer=600,
         builderNames=["openwrt-19.07"]
     )
 )
@@ -114,7 +114,7 @@ c['schedulers'].append(SingleBranchScheduler(
         name="build_packagefeed_openwrt2102",
         change_filter=filter.ChangeFilter(
             branch="openwrt-21.02"),
-        treeStableTimer=300,
+        treeStableTimer=600,
         builderNames=["openwrt-21.02"]
     )
 )
@@ -123,7 +123,7 @@ c['schedulers'].append(SingleBranchScheduler(
         name="build_packagefeed_testbranch",
         change_filter=filter.ChangeFilter(
             branch="feed_testbranch"),
-        treeStableTimer=60,
+        treeStableTimer=300,
         builderNames=["feed_testbranch"]
     )
 )

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -15,55 +15,51 @@ from worker import build_worker, workernames
 c['workers'] = build_worker
 
 
-# targets for snapshots
-snapshot_targets = [
-    "ath79",
-    "ipq40xx",
-    "mpc85xx",
-    "ramips"
+targets_2102_snapshot = [
+    "ath79/generic",
+    "ath79/mikrotik",
+    "ipq40xx/generic",
+    "ipq40xx/mikrotik",
+    "ramips/mt7621",
+    "mpc85xx/p1010"
 ]
 
-# builder-names correspond to openwrt-targets
-builder_names = [
-    "apm821xx",
-    "ar71xx",
-    "arc770",
-    "archs38",
-    "armvirt",
-    "at91",
-    "ath25",
-    "bcm53xx",
-    "brcm2708",
-    "brcm47xx",
-    "brcm63xx",
-    "cns3xxx",
-    "gemini",
-    "imx6",
-    "ipq806x",
-    "kirkwood",
-    "lantiq",
-    "layerscape",
-    "malta",
-    "mediatek",
-    "mvebu",
-    "mxs",
-    "octeon",
-    "octeontx",
-    "omap",
-    "oxnas",
-    "pistachio",
-    "rb532",
-    "samsung",
-    "sunxi",
-    "tegra",
-    "x86",
-    "zynq"
-    ] + snapshot_targets
+# tragets since openwrt-21.02
+targets_2102 = [
+    "ath79/nand",
+    "bcm27xx/bcm2708",
+    "bcm27xx/bcm2709",
+    "bcm27xx/bcm2710",
+    "bcm27xx/bcm2711",
+    "bcm47xx/generic",
+    "bcm47xx/legacy",
+    "bcm47xx/mips74k",
+    "bcm53xx/generic",
+    "bcm63xx/generic",
+    "bcm63xx/smp",
+    "ipq806x/generic",
+    "lantiq/ase",
+    "lantiq/xrx200",
+    "lantiq/xway",
+    "lantiq/xway_legacy",
+    "mediatek/mt7622",
+    "mediatek/mt7623",
+    "mediatek/mt7629",
+    "mpc85xx/p1020",
+    "mpc85xx/p2020",
+    "octeon/generic",
+    "ramips/mt7620",
+    "ramips/mt76x8",
+    "x86/64",
+    "x86/generic",
+    "x86/geode",
+    "x86/legacy"
+] + targets_2102_snapshot
+
 
 # builder-names correspond to branches in falter-packages-repository.
 feed_builders = [
     "master",
-    "openwrt-19.07",
     "openwrt-21.02",
     "feed_testbranch"
     ]
@@ -80,17 +76,7 @@ from buildbot.schedulers.timed import Periodic
 from buildbot.plugins import schedulers, steps, util
 
 c['schedulers'] = []
-"""c['schedulers'].append(
-    SingleBranchScheduler(
-        name="falter githook",
-        change_filter=filter.ChangeFilter(
-            branch_re='.*',
-            repository='https://github.com/Freifunk-Spalter/builter'
-            ),
-        treeStableTimer=10,
-        builderNames=builder_names
-    )
-)"""
+
 
 c['schedulers'].append(SingleBranchScheduler(
         name="build_packagefeed_master",
@@ -98,15 +84,6 @@ c['schedulers'].append(SingleBranchScheduler(
             branch="master"),
         treeStableTimer=600,
         builderNames=["master"]
-    )
-)
-
-c['schedulers'].append(SingleBranchScheduler(
-        name="build_packagefeed_openwrt1907",
-        change_filter=filter.ChangeFilter(
-            branch="openwrt-19.07"),
-        treeStableTimer=600,
-        builderNames=["openwrt-19.07"]
     )
 )
 
@@ -129,25 +106,17 @@ c['schedulers'].append(SingleBranchScheduler(
 )
 
 c['schedulers'].append(Periodic(
-    name="weekly",
-    branch="feature/build_all_packagesets",
-    builderNames=builder_names,
-    periodicBuildTimer=7*24*60*60
-    )
-)
-
-c['schedulers'].append(Periodic(
-    name="daily_master",
-    branch="feature/build_all_packagesets",
-    builderNames=builder_names,
-    periodicBuildTimer=24*60*60
+    name="build snapshots every two days",
+    branch="master",
+    builderNames=targets_2102_snapshot,
+    periodicBuildTimer=2*24*60*60
     )
 )
 
 c['schedulers'].append(
 	ForceScheduler(
         name="force_building_images",
-        builderNames=builder_names
+        builderNames=targets_2102
         )
 	)
 
@@ -162,7 +131,7 @@ c['schedulers'].append(
 c['schedulers'].append(
     schedulers.Triggerable(
         name="trigger_snapshots",
-        builderNames=snapshot_targets
+        builderNames=targets_2102_snapshot
     )
 )
 
@@ -186,7 +155,7 @@ from datetime import date
 from buildsteps_image import *
 from buildsteps_feed import *
 
-c['builders'] = list(map(create_builder_config, builder_names))
+c['builders'] = list(map(create_builder_config, targets_2102))
 c['builders'].extend(list(map(create_feed_builder, feed_builders)))
 
 

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -286,10 +286,11 @@ feed_create_tmpdir = ShellCommand(
 def feed_make_command(props):
     command = ['nice',
 	'./build_all_targets',
-	'19.07.5']
-	feed_branch = util.Property('buildername').split(sep='_')[-1]
-	command.extend('src-git falter https://github.com/Freifunk-Spalter/packages.git;'+feed_branch)
-	command.extend(Interpolate('%(prop:builddir)s/tmp'))
+	'19.07.5',
+        Interpolate('src-git falter https://github.com/Freifunk-Spalter/packages.git;%(prop:buildername)s'),
+        Interpolate('%(prop:builddir)s/tmp'),
+        'build_parallel'
+        ]
     return command
 
 feed_make = ShellCommand(

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -5,7 +5,7 @@ import re
 
 c = BuildmasterConfig = {}
 
-c['title'] = "Freifunk"
+c['title'] = "Freifunk-Falter"
 c['titleURL'] = "http://berlin.freifunk.net"
 c['buildbotURL'] = "http://buildbot.berlin.freifunk.net/"
 c['db_url'] = "sqlite:///state.sqlite"
@@ -38,7 +38,7 @@ c['schedulers'].append(
         name="berlin githook",
         change_filter=filter.ChangeFilter(
             branch_re='.*',
-            repository='https://github.com/freifunk-berlin/firmware'
+            repository='https://github.com/Freifunk-Spalter/falter-buildsystem'
             ),
         treeStableTimer=10,
         builderNames=builder_names
@@ -70,10 +70,10 @@ def is_release_step(step):
 
 
 cmd_checkoutSource = Git(
-    repourl='git://github.com/freifunk-berlin/firmware.git',
-    branch="master",   # this can get changed by html.WebStatus.change_hook()
+    repourl='git://github.com/Freifunk-Spalter/falter-buildsystem.git',
+    branch="falter-19.07",   # this can get changed by html.WebStatus.change_hook()
                        # by notification from GitHub of a commit
-    workdir="build/firmware",
+    workdir="build/falter-buildsystem",
     mode='full'
     )
 
@@ -116,7 +116,7 @@ def cmd_make_command(props):
 
 cmd_make = ShellCommand(
     command=cmd_make_command,
-    workdir="build/firmware",
+    workdir="build/falter-buildsystem",
     haltOnFailure=True
     )
 
@@ -133,7 +133,7 @@ cmd_mastermkdir = MasterShellCommand(
     ])
 
 slave_src_directory = Interpolate(
-    "firmware/firmwares/%(prop:buildername)s/"
+    "falter-buildsystem/firmwares/%(prop:buildername)s/"
 )
 
 cmd_uploadPackages = DirectoryUpload(
@@ -150,7 +150,7 @@ cmd_masterchmod = MasterShellCommand(
     ])
 
 cmd_cleanup = RemoveDirectory(
-    dir="build/firmware",
+    dir="build/falter-buildsystem",
     alwaysRun=True
     )
 
@@ -199,8 +199,8 @@ c['builders'] = list(map(create_builder_config, builder_names))
 
 c['www'] = dict(
 	port=8010,
-	plugins=dict(waterfall_view={}, console_view={}, grid_view={}),
-	change_hook_dialects={ 'github': { 'secret': 'c3600bf6160cf2c8536b260111b97a339', 'strict': True } },
+	plugins=dict(waterfall_view={}, console_view={}, grid_view={})#,
+	#change_hook_dialects={ 'github': { 'secret': 'c3600bf6160cf2c8536b260111b97a339', 'strict': True } },
 )
 
 c['protocols'] = { 'pb': { 'port': 9989 } }

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -77,7 +77,7 @@ from buildbot.plugins import schedulers, steps, util
 
 c['schedulers'] = []
 
-
+# compile new feed for 'master' when triggered via webhook
 c['schedulers'].append(SingleBranchScheduler(
         name="build_packagefeed_master",
         change_filter=filter.ChangeFilter(
@@ -87,6 +87,7 @@ c['schedulers'].append(SingleBranchScheduler(
     )
 )
 
+# compile new feed for 'openwrt-21.02' when triggered via webhook
 c['schedulers'].append(SingleBranchScheduler(
         name="build_packagefeed_openwrt2102",
         change_filter=filter.ChangeFilter(
@@ -96,6 +97,7 @@ c['schedulers'].append(SingleBranchScheduler(
     )
 )
 
+# compile new feed for 'feed_testbranch' when triggered via webhook
 c['schedulers'].append(SingleBranchScheduler(
         name="build_packagefeed_testbranch",
         change_filter=filter.ChangeFilter(
@@ -113,6 +115,16 @@ c['schedulers'].append(Periodic(
     )
 )
 
+c['schedulers'].append(Periodic(
+    name="build 1.2.0-snapshots every three days",
+    branch="master",
+    builderNames=targets_2102_snapshot,
+    properties={"falterVersion": "1.2.0-snapshot"},
+    periodicBuildTimer=3*24*60*60
+    )
+)
+
+# force building button for image-builders
 c['schedulers'].append(
 	ForceScheduler(
         name="force_building_images",
@@ -120,6 +132,7 @@ c['schedulers'].append(
         )
 	)
 
+# force building button for feed-builders
 c['schedulers'].append(
     ForceScheduler(
         name="force_building_packagefeed",

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -10,17 +10,12 @@ c['titleURL'] = "http://berlin.freifunk.net"
 c['buildbotURL'] = "http://buildbot.berlin.freifunk.net/"
 c['db_url'] = "sqlite:///state.sqlite"
 
-# SLAVES
-from slaves import build_slaves, slavenames
-c['workers'] = build_slaves
-#c['slavePortnum'] = 9989
+# Workers
+from worker import build_worker, workernames
+c['workers'] = build_worker
 
-# SCHEDULERS
-from buildbot.schedulers.basic import SingleBranchScheduler
-from buildbot.schedulers.forcesched import ForceScheduler
-from buildbot.changes import filter
-from buildbot.schedulers.timed import Periodic
 
+# builder-names correspond to openwrt-targets
 builder_names = [
     "apm821xx",
     "ar71xx",
@@ -61,13 +56,21 @@ builder_names = [
     "zynq"
     ]
 
-# define the branche-names, that we want to build a package repo from
+# builder-names correspond to branches in falter-packages-repository.
 feed_builders = [
     "master",
     "openwrt-19.07"
     ]
 
 
+
+##################
+#   Schedulers   #
+##################
+from buildbot.schedulers.basic import SingleBranchScheduler
+from buildbot.schedulers.forcesched import ForceScheduler
+from buildbot.changes import filter
+from buildbot.schedulers.timed import Periodic
 
 c['schedulers'] = []
 """c['schedulers'].append(
@@ -124,7 +127,10 @@ c['schedulers'].append(
 
 
 
-# BUILDERS
+################
+#   BUILDERS   #
+################
+
 from buildbot.process.factory import BuildFactory
 from buildbot.config import BuilderConfig
 from buildbot.steps.source.git import Git
@@ -135,259 +141,18 @@ from buildbot.process.properties import Interpolate, renderer
 from buildbot.steps.worker import RemoveDirectory
 from datetime import date
 
-
-def is_release_step(step):
-    branch = step.getProperty("branch") or 'was_not_set'
-    return re.match(".*\d+\.\d+\.\d+$", branch)
-
-
-cmd_checkoutSource = Git(
-    repourl='git://github.com/Freifunk-Spalter/builter',
-    branch="master",   # this can get changed by html.WebStatus.change_hook()
-                       # by notification from GitHub of a commit
-    workdir="build/falter-builter",
-    mode='full'
-    )
-
-feed_conf_interpolate = Interpolate(
-    "'s/\(packages_berlin\.git\^\)\([a-f0-9]\{40,40\}\)/\1%(prop:revision)s/'"
-    ),
-
-def repo_url(props):
-    base_url = "http://buildbot.berlin.freifunk.net/buildbot"
-    branch = props.getProperty("branch")
-    target = props.getProperty("buildername")
-    is_release_branch = re.match("\d+\.\d+\.\d+$", branch)
-    if is_release_branch:
-        return "{}/stable/{}/{}/packages".format(
-            base_url,
-            branch,
-            target
-            )
-    else:
-        return "{}/unstable/{}/{}/packages".format(
-            base_url,
-            target,
-            props.getProperty("buildnumber")
-            )
-
-
-@renderer
-def cmd_make_command(props):
-    command = ['nice', './build_falter']
-    #cpus = props.getProperty('cpus_per_build')
-    #if cpus:
-    #    command.extend(['-j', str(cpus+1)])
-    #else:
-    #    command.extend(['-j', '2'])
-    command.extend(["all"])
-    command.extend(["19.07"])
-    command.extend([props.getProperty('buildername')])
-    #command.extend(["VERSION_REPO=" + repo_url(props)])
-    #command.extend(['IS_BUILDBOT=yes'])
-    return command
-
-
-cmd_make = ShellCommand(
-    command=cmd_make_command,
-    workdir="build/falter-builter",
-    haltOnFailure=True
-    )
-
-#upload_branch_name = Interpolate("%(prop:branch)s/")
-upload_directory = Interpolate("/usr/local/src/www/htdocs/buildbot/unstable/"+ date.today().strftime("%Y-%m-%d") +"/%(prop:branch)s/")
-
-cmd_mastermkdir = MasterShellCommand(
-    command=[
-        "mkdir",
-        "-p",
-        "--mode=a+rx",
-        upload_directory
-    ])
-
-slave_src_directory = Interpolate(
-    "falter-builter/firmwares/"
-)
-
-cmd_uploadPackages = DirectoryUpload(
-    workersrc=slave_src_directory,
-    masterdest=upload_directory
-    )
-
-cmd_masterchmod = MasterShellCommand(
-    command=[
-        "chmod",
-        "-R",
-        "o+rX",
-        upload_directory
-    ])
-
-cmd_cleanup = RemoveDirectory(
-    dir="build/falter-builter",
-    alwaysRun=True
-    )
-
-cmd_rsync_release = MasterShellCommand(
-    command=[
-        "rsync",
-        "-av",
-        "--delete",
-        upload_directory,
-        Interpolate("/usr/local/src/www/htdocs/buildbot/stable/%(prop:branch)s/%(prop:buildername)s")
-        ],
-    doStepIf=is_release_step
-    )
-
-cmd_create_release_dir = MasterShellCommand(
-    command=[
-        "mkdir",
-        "-m755",
-        "-p",
-        Interpolate("/usr/local/src/www/htdocs/buildbot/stable/%(prop:branch)s/")
-        ],
-    doStepIf=is_release_step
-    )
-
-image_factory = BuildFactory([
-    cmd_checkoutSource,
-    cmd_make,
-    cmd_mastermkdir,
-    cmd_uploadPackages,
-    cmd_masterchmod,
-    cmd_create_release_dir,
-    cmd_rsync_release,
-    cmd_cleanup
-    ])
-
-def create_builder_config(builder_name):
-    return BuilderConfig(
-        name=builder_name,
-        workernames=slavenames,
-        factory=image_factory
-    )
-
-
-
-feed_checkoutSource = Git(
-    repourl='git://github.com/Freifunk-Spalter/repo_builder',
-    branch="master",   # this can get changed by html.WebStatus.change_hook()
-                       # by notification from GitHub of a commit
-    workdir="build/falter-repo-builder",
-    mode='full'
-    )
-
-feed_create_tmpdir = ShellCommand(
-    name="create tmp dir",
-    command=[
-    "mkdir",
-    "-p",
-    "tmp"
-    ])
-
-@renderer
-def feed_make_command(props):
-    command = ['nice',
-	'./build_all_targets',
-	'19.07.5',
-        Interpolate('src-git falter https://github.com/Freifunk-Spalter/packages.git;%(prop:buildername)s'),
-        Interpolate('%(prop:builddir)s/tmp'),
-        'build_parallel'
-        ]
-    return command
-
-feed_make = ShellCommand(
-    name="build feed",
-    command=feed_make_command,
-    workdir="build/falter-repo-builder",
-    haltOnFailure=True
-    )
-
-upload_dir = Interpolate("/usr/local/src/www/htdocs/buildbot/feed/new/%(prop:buildername)s/")
-feed_master_empty_dir = MasterShellCommand(
-    name="clear upload dir",
-    command=[
-        "rm",
-        "-rf",
-        upload_dir
-        ]
-)
-
-feed_mastermkdir = MasterShellCommand(
-    name="create upload dir",
-    command=[
-        "mkdir",
-        "-p",
-        "--mode=a+rx",
-        upload_dir
-        ]
-)
-
-worker_src_dir = Interpolate("%(prop:builddir)s/tmp/")
-feed_uploadPackages = DirectoryUpload(
-    workersrc=worker_src_dir,
-    masterdest=upload_dir
-    )
-
-feed_masterchmod = MasterShellCommand(
-    name="chmod upload dir",
-    command=[
-        "chmod",
-        "-R",
-        "o+rX",
-        upload_dir
-    ])
-
-feed_sign_packages = MasterShellCommand(
-    name="sign packages",
-    command=[
-        "/usr/local/src/sign_packages.sh",
-        upload_dir
-        ]
-)
-
-
-#def feed_branch_stable(step):
-#    branch = step.getProperty("branch") or 'was_not_set'
-#    return re.match(".*\d+\.\d+$", branch)
-
-# TODO: Nicht der branch vom repo-builder, sondern der branch aus der githook (package-repo)
-#stable_dir = Interpolate("/usr/local/src/www/htdocs/buildbot/feed/%(prop:branch)s/")
-#feed_move_feed_stable = MasterShellCommand(
-#    command=[
-#        "rm", "-rf", stable_dir, "&&",
-#        "mv", upload_dir, stable_dir
-#    ],
-#    doStepIf=feed_branch_stable
-#)
-
-feed_cleanup = RemoveDirectory(
-    dir="build/falter-repo-builder",
-    alwaysRun=True
-    )
-
-feed_factory = BuildFactory([
-    feed_checkoutSource,
-    feed_create_tmpdir,
-    feed_make,
-    feed_master_empty_dir,
-    feed_mastermkdir,
-    feed_uploadPackages,
-    feed_masterchmod,
-    feed_sign_packages,
-    feed_cleanup
-    ])
-
-def create_feed_builder(builder_name):
-    return BuilderConfig(
-        name=builder_name,
-        workernames=slavenames,
-        factory=feed_factory
-    )
-
+# define buildsteps and factories in seperate files
+from buildsteps_image import *
+from buildsteps_feed import *
 
 c['builders'] = list(map(create_builder_config, builder_names))
 c['builders'].extend(list(map(create_feed_builder, feed_builders)))
 
+
+
+#####################
+#   Web-Interface   #
+#####################
 
 c['www'] = dict(
 	port=8010,
@@ -401,6 +166,7 @@ c['www'] = dict(
 )
 
 c['protocols'] = { 'pb': { 'port': 9989 } }
+
 
 # STATUS TARGETS
 #from buildbot.status import html

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -6,8 +6,8 @@ import re
 c = BuildmasterConfig = {}
 
 c['title'] = "Freifunk-Falter"
-c['titleURL'] = "http://berlin.freifunk.net"
-c['buildbotURL'] = "http://buildbot.berlin.freifunk.net/"
+c['titleURL'] = "https://berlin.freifunk.net"
+c['buildbotURL'] = "https://buildbot.berlin.freifunk.net/"
 c['db_url'] = "sqlite:///state.sqlite"
 
 # Workers

--- a/masters/master/master.cfg
+++ b/masters/master/master.cfg
@@ -61,8 +61,8 @@ targets_2102 = [
 feed_builders = [
     "master",
     "openwrt-21.02",
-    "upstream/21.02-perry"
-    "feed_testbranch",
+    "upstream/21.02-perry",
+    "feed_testbranch"
     ]
 
 


### PR DESCRIPTION
We migrate the repos from the falter-organisation to freifunk-berlin. For buildbot this is fairly easy, as we just forked the repo.